### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,45 @@
-RAG Setup s Ollama
-# RAG Setup s Ollama
-Základní setup pro RAG s Ollama a DeepSeek-R1.
-Spuštění
-bash# Spuštění Ollama
+# MESRAG
 
-## Spuštění Ollama
+MESRAG is a simple Retrieval Augmented Generation (RAG) stack built around
+[Ollama](https://ollama.ai/) and Qdrant. Documents are imported through a
+FastAPI service that enriches them with ISA‑95 role metadata. A small Next.js
+frontend is provided for quick experimentation.
 
-```bash
-docker-compose up -d
+## Getting Started
+
+1. **Start the stack**
+   ```bash
+   docker-compose up -d
+   ```
+2. **Pull the model inside the Ollama container**
+   ```bash
+   docker exec -it ollama ollama pull deepseek-r1
+   ```
+3. **Open the web UI and importer endpoints**
+   - Frontend: <http://localhost:3000>
+   - Importer API: <http://localhost:8001/trigger-import>
+   - Embedding API: <http://localhost:8001/embed>
+4. **Run the tests**
+   ```bash
+   PYTHONPATH=rag-backend pytest
+   ```
+
+## Directory Layout
+
+```
+├── docker-compose.yml  # container stack
+├── frontend/           # Next.js UI
+├── rag-backend/        # import service and tests
+│   └── data/import/    # pending, processed and failed files
+├── docs/               # project documentation
+└── init.sh             # startup script for Ollama
 ```
 
-## Stáhnutí modelu
+`rag-backend/import_documents.py` extracts metadata from filenames and stores
+it as payload fields in Qdrant. Departments are mapped to role tags, enabling an
+ISA‑95 style RBAC mechanism. File names also encode the location hierarchy which
+is saved as metadata for later filtering.
 
-# Stáhnutí modelu
-```bash
-docker exec -it ollama ollama pull deepseek-r1
-```
+Use `/trigger-import` to process files from `rag-backend/data/import/pending`.
+Successful files are moved to `processed` and vectors are written to Qdrant.
 
-# Test
-## Test
-
-```bash
-curl http://localhost:11434/api/generate -d '{
-  "model": "deepseek-r1",
-  "prompt": "Ahoj, jak se máš?",
-  "stream": false
-}'
-Porty
-```
-
-## Porty
-
-Ollama API: http://localhost:11434
-
-Užitečné příkazy
-bash# Zobrazit běžící modely
-## Užitečné příkazy
-
-### Zobrazit běžící modely
-
-```bash
-docker exec -it ollama ollama list
-```
-
-### Zastavit
-
-# Zastavit
-```bash
-docker-compose down
-```
-
-### Smazat volume (všechna data)
-
-```bash
-docker-compose down -v
-```
-
-# Smazat volume (všechna data)
-docker-compose down -v


### PR DESCRIPTION
## Summary
- clean up the README
- outline starting the stack and pulling the model
- document endpoints, tests and directory structure

## Testing
- `PYTHONPATH=rag-backend pytest -q` *(fails: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_68741055dad48325bb1226e3136cef6f